### PR TITLE
Add ESLint flat config shim for Expo and Prettier

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,20 @@
+/**
+ * ESLint flat config shim to reuse the existing Expo + Prettier settings.
+ * Keeps behaviour consistent with the prior .eslintrc.js while satisfying ESLint 9.
+ */
+
+const { FlatCompat } = require('@eslint/eslintrc');
+const path = require('path');
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  resolvePluginsRelativeTo: __dirname,
+});
+
+module.exports = compat.config({
+  extends: ['expo', 'prettier'],
+  plugins: ['prettier'],
+  rules: {
+    'prettier/prettier': 'warn',
+  },
+});


### PR DESCRIPTION
This config shim maintains compatibility with ESLint 9 while reusing existing Expo and Prettier settings.