### PR TITLE
feat(automerge): implement Phase 3 - History Feature UI

### DIFF
--- a/app/trips/[id]/history.tsx
+++ b/app/trips/[id]/history.tsx
@@ -1,0 +1,6 @@
+/**
+ * ROUTING: Trip History Screen Route
+ * Displays chronological timeline of all changes to a trip
+ */
+
+export { default } from "@modules/history/screens/TripHistoryScreen";

--- a/src/modules/automerge/engine/history-parser.ts
+++ b/src/modules/automerge/engine/history-parser.ts
@@ -1,0 +1,466 @@
+/**
+ * AUTOMERGE MODULE - History Parser Engine
+ * MODELER: Pure functions for parsing Automerge operation log into human-readable changes
+ * PURE FUNCTIONS: No side effects, no dependencies (except types)
+ *
+ * This module parses Automerge's getHistory() output into structured change events
+ * that can be displayed in the UI. Each change represents a single modification
+ * to the trip document (add participant, update expense, etc.)
+ */
+
+import type * as Automerge from "@automerge/automerge";
+import type { TripAutomergeDoc } from "../types";
+
+/**
+ * Type of change made to the document
+ */
+export type ChangeType =
+  | "trip_created"
+  | "trip_updated"
+  | "participant_added"
+  | "participant_updated"
+  | "participant_removed"
+  | "expense_added"
+  | "expense_updated"
+  | "expense_removed"
+  | "settlement_added"
+  | "settlement_updated"
+  | "settlement_removed"
+  | "unknown";
+
+/**
+ * Parsed change event
+ */
+export interface ParsedChange {
+  /** Type of change */
+  type: ChangeType;
+  /** ISO timestamp of the change */
+  timestamp: string;
+  /** Human-readable change message from Automerge */
+  message: string;
+  /** Actor ID who made the change */
+  actorId: string;
+  /** Raw change object from Automerge */
+  rawChange: Automerge.DecodedChange;
+  /** Parsed details about what changed */
+  details: ChangeDetails;
+}
+
+/**
+ * Details about what changed in a specific modification
+ */
+export interface ChangeDetails {
+  /** For participant/expense/settlement changes: the ID of the entity */
+  entityId?: string;
+  /** For entity updates: field-level changes */
+  fieldChanges?: FieldChange[];
+  /** Snapshot of the entity before the change (if available) */
+  beforeSnapshot?: unknown;
+  /** Snapshot of the entity after the change */
+  afterSnapshot?: unknown;
+}
+
+/**
+ * Represents a single field change
+ */
+export interface FieldChange {
+  fieldPath: string;
+  oldValue: unknown;
+  newValue: unknown;
+}
+
+/**
+ * Parse Automerge history into human-readable change events
+ *
+ * Takes the output of Automerge.getHistory() and converts it into
+ * structured change events that can be displayed in the UI.
+ *
+ * @param history - Array of states from Automerge.getHistory()
+ * @returns Array of parsed changes, sorted newest-first
+ *
+ * @example
+ * const history = Automerge.getHistory(doc);
+ * const changes = parseHistory(history);
+ * // changes[0] = { type: 'expense_added', timestamp: '2024-01-01T00:00:00Z', ... }
+ */
+export function parseHistory(
+  history: { change: Automerge.DecodedChange; snapshot: TripAutomergeDoc }[],
+): ParsedChange[] {
+  const changes: ParsedChange[] = [];
+
+  for (let i = 0; i < history.length; i++) {
+    const { change, snapshot } = history[i];
+    const previousSnapshot = i > 0 ? history[i - 1].snapshot : null;
+
+    const parsedChange = parseChange(change, snapshot, previousSnapshot);
+    changes.push(parsedChange);
+  }
+
+  // Sort newest-first (reverse chronological)
+  return changes.reverse();
+}
+
+/**
+ * Parse a single Automerge change into a structured event
+ *
+ * @param change - The decoded Automerge change
+ * @param snapshot - Document state after this change
+ * @param previousSnapshot - Document state before this change (or null if first change)
+ * @returns Parsed change event
+ */
+function parseChange(
+  change: Automerge.DecodedChange,
+  snapshot: TripAutomergeDoc,
+  previousSnapshot: TripAutomergeDoc | null,
+): ParsedChange {
+  const message = change.message || "Untitled change";
+  const timestamp = change.time
+    ? new Date(change.time * 1000).toISOString()
+    : new Date().toISOString();
+  const actorId = change.actor;
+
+  // Determine change type by analyzing the message
+  const type = inferChangeType(message);
+  const details = extractChangeDetails(
+    type,
+    message,
+    snapshot,
+    previousSnapshot,
+  );
+
+  return {
+    type,
+    timestamp,
+    message,
+    actorId,
+    rawChange: change,
+    details,
+  };
+}
+
+/**
+ * Infer change type from the change message
+ *
+ * This analyzes the message string that was passed to Automerge.change()
+ * to determine what kind of change it represents.
+ *
+ * @param message - The change message (e.g., "Add participant", "Update expense")
+ * @returns The inferred change type
+ */
+function inferChangeType(message: string): ChangeType {
+  const lowerMessage = message.toLowerCase();
+
+  // Trip changes
+  if (
+    lowerMessage.includes("initialize trip") ||
+    lowerMessage === "initialized"
+  ) {
+    return "trip_created";
+  }
+  if (lowerMessage.includes("update trip")) {
+    return "trip_updated";
+  }
+
+  // Participant changes
+  if (lowerMessage.includes("add participant")) {
+    return "participant_added";
+  }
+  if (lowerMessage.includes("update participant")) {
+    return "participant_updated";
+  }
+  if (lowerMessage.includes("remove participant")) {
+    return "participant_removed";
+  }
+
+  // Expense changes
+  if (lowerMessage.includes("add expense")) {
+    return "expense_added";
+  }
+  if (lowerMessage.includes("update expense")) {
+    return "expense_updated";
+  }
+  if (lowerMessage.includes("remove expense")) {
+    return "expense_removed";
+  }
+
+  // Settlement changes
+  if (lowerMessage.includes("add settlement")) {
+    return "settlement_added";
+  }
+  if (lowerMessage.includes("update settlement")) {
+    return "settlement_updated";
+  }
+  if (lowerMessage.includes("remove settlement")) {
+    return "settlement_removed";
+  }
+
+  return "unknown";
+}
+
+/**
+ * Extract detailed information about what changed
+ *
+ * This compares the before/after snapshots to identify exactly
+ * what entities and fields were modified.
+ *
+ * @param type - The change type
+ * @param message - The change message
+ * @param snapshot - Document state after change
+ * @param previousSnapshot - Document state before change (or null)
+ * @returns Change details
+ */
+function extractChangeDetails(
+  type: ChangeType,
+  message: string,
+  snapshot: TripAutomergeDoc,
+  previousSnapshot: TripAutomergeDoc | null,
+): ChangeDetails {
+  // If no previous snapshot, this is the initial creation
+  if (!previousSnapshot) {
+    return {
+      afterSnapshot: snapshot,
+    };
+  }
+
+  // Detect participant changes
+  if (type.startsWith("participant_")) {
+    return extractParticipantChanges(type, snapshot, previousSnapshot);
+  }
+
+  // Detect expense changes
+  if (type.startsWith("expense_")) {
+    return extractExpenseChanges(type, snapshot, previousSnapshot);
+  }
+
+  // Detect settlement changes
+  if (type.startsWith("settlement_")) {
+    return extractSettlementChanges(type, snapshot, previousSnapshot);
+  }
+
+  // Detect trip metadata changes
+  if (type === "trip_updated") {
+    return extractTripChanges(snapshot, previousSnapshot);
+  }
+
+  return {};
+}
+
+/**
+ * Extract participant-specific changes
+ */
+function extractParticipantChanges(
+  type: ChangeType,
+  snapshot: TripAutomergeDoc,
+  previousSnapshot: TripAutomergeDoc,
+): ChangeDetails {
+  const currentParticipants = Object.keys(snapshot.participants);
+  const previousParticipants = Object.keys(previousSnapshot.participants);
+
+  if (type === "participant_added") {
+    // Find newly added participant
+    const newId = currentParticipants.find(
+      (id) => !previousParticipants.includes(id),
+    );
+    if (newId) {
+      return {
+        entityId: newId,
+        afterSnapshot: snapshot.participants[newId],
+      };
+    }
+  } else if (type === "participant_removed") {
+    // Find removed participant
+    const removedId = previousParticipants.find(
+      (id) => !currentParticipants.includes(id),
+    );
+    if (removedId) {
+      return {
+        entityId: removedId,
+        beforeSnapshot: previousSnapshot.participants[removedId],
+      };
+    }
+  } else if (type === "participant_updated") {
+    // Find updated participant
+    for (const id of currentParticipants) {
+      if (previousParticipants.includes(id)) {
+        const before = previousSnapshot.participants[id];
+        const after = snapshot.participants[id];
+        const fieldChanges = compareObjects(before, after);
+        if (fieldChanges.length > 0) {
+          return {
+            entityId: id,
+            fieldChanges,
+            beforeSnapshot: before,
+            afterSnapshot: after,
+          };
+        }
+      }
+    }
+  }
+
+  return {};
+}
+
+/**
+ * Extract expense-specific changes
+ */
+function extractExpenseChanges(
+  type: ChangeType,
+  snapshot: TripAutomergeDoc,
+  previousSnapshot: TripAutomergeDoc,
+): ChangeDetails {
+  const currentExpenses = Object.keys(snapshot.expenses);
+  const previousExpenses = Object.keys(previousSnapshot.expenses);
+
+  if (type === "expense_added") {
+    const newId = currentExpenses.find((id) => !previousExpenses.includes(id));
+    if (newId) {
+      return {
+        entityId: newId,
+        afterSnapshot: snapshot.expenses[newId],
+      };
+    }
+  } else if (type === "expense_removed") {
+    const removedId = previousExpenses.find(
+      (id) => !currentExpenses.includes(id),
+    );
+    if (removedId) {
+      return {
+        entityId: removedId,
+        beforeSnapshot: previousSnapshot.expenses[removedId],
+      };
+    }
+  } else if (type === "expense_updated") {
+    for (const id of currentExpenses) {
+      if (previousExpenses.includes(id)) {
+        const before = previousSnapshot.expenses[id];
+        const after = snapshot.expenses[id];
+        const fieldChanges = compareObjects(before, after);
+        if (fieldChanges.length > 0) {
+          return {
+            entityId: id,
+            fieldChanges,
+            beforeSnapshot: before,
+            afterSnapshot: after,
+          };
+        }
+      }
+    }
+  }
+
+  return {};
+}
+
+/**
+ * Extract settlement-specific changes
+ */
+function extractSettlementChanges(
+  type: ChangeType,
+  snapshot: TripAutomergeDoc,
+  previousSnapshot: TripAutomergeDoc,
+): ChangeDetails {
+  const currentSettlements = Object.keys(snapshot.settlements);
+  const previousSettlements = Object.keys(previousSnapshot.settlements);
+
+  if (type === "settlement_added") {
+    const newId = currentSettlements.find(
+      (id) => !previousSettlements.includes(id),
+    );
+    if (newId) {
+      return {
+        entityId: newId,
+        afterSnapshot: snapshot.settlements[newId],
+      };
+    }
+  } else if (type === "settlement_removed") {
+    const removedId = previousSettlements.find(
+      (id) => !currentSettlements.includes(id),
+    );
+    if (removedId) {
+      return {
+        entityId: removedId,
+        beforeSnapshot: previousSnapshot.settlements[removedId],
+      };
+    }
+  } else if (type === "settlement_updated") {
+    for (const id of currentSettlements) {
+      if (previousSettlements.includes(id)) {
+        const before = previousSnapshot.settlements[id];
+        const after = snapshot.settlements[id];
+        const fieldChanges = compareObjects(before, after);
+        if (fieldChanges.length > 0) {
+          return {
+            entityId: id,
+            fieldChanges,
+            beforeSnapshot: before,
+            afterSnapshot: after,
+          };
+        }
+      }
+    }
+  }
+
+  return {};
+}
+
+/**
+ * Extract trip metadata changes
+ */
+function extractTripChanges(
+  snapshot: TripAutomergeDoc,
+  previousSnapshot: TripAutomergeDoc,
+): ChangeDetails {
+  const fieldChanges = compareObjects(
+    {
+      name: previousSnapshot.name,
+      emoji: previousSnapshot.emoji,
+      currency: previousSnapshot.currency,
+      startDate: previousSnapshot.startDate,
+      endDate: previousSnapshot.endDate,
+    },
+    {
+      name: snapshot.name,
+      emoji: snapshot.emoji,
+      currency: snapshot.currency,
+      startDate: snapshot.startDate,
+      endDate: snapshot.endDate,
+    },
+  );
+
+  return {
+    fieldChanges,
+    beforeSnapshot: previousSnapshot,
+    afterSnapshot: snapshot,
+  };
+}
+
+/**
+ * Compare two objects and return field-level changes
+ *
+ * @param before - Object before change
+ * @param after - Object after change
+ * @returns Array of field changes
+ */
+function compareObjects(before: any, after: any): FieldChange[] {
+  const changes: FieldChange[] = [];
+  const allKeys = new Set([...Object.keys(before), ...Object.keys(after)]);
+
+  for (const key of allKeys) {
+    // Skip metadata fields and nested objects
+    if (key === "createdAt" || key === "updatedAt" || key === "splits") {
+      continue;
+    }
+
+    const oldValue = before[key];
+    const newValue = after[key];
+
+    if (JSON.stringify(oldValue) !== JSON.stringify(newValue)) {
+      changes.push({
+        fieldPath: key,
+        oldValue,
+        newValue,
+      });
+    }
+  }
+
+  return changes;
+}

--- a/src/modules/automerge/hooks/index.ts
+++ b/src/modules/automerge/hooks/index.ts
@@ -4,3 +4,6 @@
 
 export { useAutomergeDoc } from "./use-automerge-doc";
 export type { UseAutomergeDocResult } from "./use-automerge-doc";
+
+export { useTripHistory } from "./use-trip-history";
+export type { UseTripHistoryResult } from "./use-trip-history";

--- a/src/modules/automerge/hooks/use-trip-history.ts
+++ b/src/modules/automerge/hooks/use-trip-history.ts
@@ -1,0 +1,119 @@
+/**
+ * AUTOMERGE MODULE - useTripHistory Hook
+ * UI INTEGRATION: React hook for accessing trip's Automerge operation log
+ *
+ * This hook loads a trip's Automerge document and extracts the change history
+ * using Automerge.getHistory(). It returns parsed changes ready for display.
+ */
+
+import { useState, useEffect, useMemo } from "react";
+import * as Automerge from "@automerge/automerge";
+import { AutomergeManager } from "../service/AutomergeManager";
+import { parseHistory } from "../engine/history-parser";
+import type { ParsedChange } from "../engine/history-parser";
+import type { TripAutomergeDoc } from "../types";
+import { createAppError } from "@utils/errors";
+
+/**
+ * Hook result
+ */
+export interface UseTripHistoryResult {
+  /** Parsed changes from Automerge history */
+  changes: ParsedChange[];
+  /** Loading state */
+  loading: boolean;
+  /** Error state */
+  error: Error | null;
+  /** Refetch function */
+  refetch: () => Promise<void>;
+}
+
+/**
+ * Hook to load and query a trip's Automerge operation log
+ *
+ * This hook:
+ * 1. Loads the trip's Automerge document
+ * 2. Calls Automerge.getHistory() to get all changes
+ * 3. Parses changes into structured events
+ * 4. Returns parsed changes sorted newest-first
+ *
+ * @param tripId - Trip UUID
+ * @returns Hook result with changes, loading state, and error
+ *
+ * @example
+ * function HistoryScreen({ tripId }) {
+ *   const { changes, loading, error } = useTripHistory(tripId);
+ *
+ *   if (loading) return <LoadingSpinner />;
+ *   if (error) return <ErrorView error={error} />;
+ *
+ *   return <HistoryTimeline changes={changes} />;
+ * }
+ */
+export function useTripHistory(tripId: string): UseTripHistoryResult {
+  const [changes, setChanges] = useState<ParsedChange[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  // Create manager instance (memoized)
+  const manager = useMemo(() => new AutomergeManager(), []);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadHistory() {
+      try {
+        setLoading(true);
+        setError(null);
+
+        // Load Automerge document
+        const doc = await manager.loadTrip(tripId);
+
+        if (!doc) {
+          throw createAppError("DOC_NOT_FOUND", "Trip document not found", {
+            details: { tripId },
+          });
+        }
+
+        // Get history from Automerge
+        const history = Automerge.getHistory(doc) as {
+          change: Automerge.DecodedChange;
+          snapshot: TripAutomergeDoc;
+        }[];
+
+        // Parse history into structured changes
+        const parsedChanges = parseHistory(history);
+
+        if (isMounted) {
+          setChanges(parsedChanges);
+          setLoading(false);
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(
+            err instanceof Error ? err : new Error("Failed to load history"),
+          );
+          setLoading(false);
+        }
+      }
+    }
+
+    loadHistory();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [tripId, manager, refreshKey]);
+
+  const refetch = async () => {
+    setRefreshKey((prev) => prev + 1);
+  };
+
+  return {
+    changes,
+    loading,
+    error,
+    refetch,
+  };
+}

--- a/src/modules/history/components/ChangeDetailCard.tsx
+++ b/src/modules/history/components/ChangeDetailCard.tsx
@@ -1,0 +1,246 @@
+/**
+ * UI/UX ENGINEER: ChangeDetailCard Component
+ * Expandable card showing detailed field-by-field changes
+ */
+
+import React, { useState } from "react";
+import { View, Text, StyleSheet, Pressable } from "react-native";
+import { theme } from "@ui/theme";
+import type { FormattedChange } from "../types";
+
+export interface ChangeDetailCardProps {
+  /** Formatted change to display */
+  change: FormattedChange;
+}
+
+/**
+ * ChangeDetailCard - Expandable card showing change details
+ *
+ * Displays a change event with:
+ * - Icon and title (always visible)
+ * - Description (always visible if present)
+ * - Field-level changes (expandable section)
+ * - Timestamp
+ *
+ * @example
+ * <ChangeDetailCard change={formattedChange} />
+ */
+export function ChangeDetailCard({ change }: ChangeDetailCardProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const hasFieldChanges = change.fieldChanges && change.fieldChanges.length > 0;
+  const canExpand = hasFieldChanges;
+
+  const handlePress = () => {
+    if (canExpand) {
+      setExpanded((prev) => !prev);
+    }
+  };
+
+  return (
+    <Pressable
+      style={({ pressed }) => [
+        styles.container,
+        pressed && canExpand && styles.pressed,
+      ]}
+      onPress={handlePress}
+      accessibilityRole={canExpand ? "button" : "none"}
+      accessibilityLabel={change.title}
+      accessibilityHint={canExpand ? "Tap to view details" : undefined}
+      accessibilityState={canExpand ? { expanded } : undefined}
+    >
+      <View style={styles.header}>
+        {/* Timeline dot */}
+        <View style={[styles.dot, { backgroundColor: change.color }]} />
+
+        {/* Content */}
+        <View style={styles.content}>
+          {/* Icon and title row */}
+          <View style={styles.titleRow}>
+            <Text style={styles.icon} accessible={false}>
+              {change.icon}
+            </Text>
+            <Text style={styles.title}>{change.title}</Text>
+          </View>
+
+          {/* Description */}
+          {change.description && (
+            <Text style={styles.description}>{change.description}</Text>
+          )}
+
+          {/* Timestamp */}
+          <Text style={styles.timestamp}>
+            {formatTimestamp(change.timestamp)}
+          </Text>
+
+          {/* Expandable field changes */}
+          {expanded && hasFieldChanges && (
+            <View style={styles.fieldChanges}>
+              <Text style={styles.fieldChangesTitle}>Changes:</Text>
+              {change.fieldChanges!.map((fieldChange, index) => (
+                <View key={index} style={styles.fieldChange}>
+                  <Text style={styles.fieldLabel}>{fieldChange.label}:</Text>
+                  <View style={styles.fieldValues}>
+                    <Text style={styles.oldValue}>{fieldChange.oldValue}</Text>
+                    <Text style={styles.arrow}>→</Text>
+                    <Text style={styles.newValue}>{fieldChange.newValue}</Text>
+                  </View>
+                </View>
+              ))}
+            </View>
+          )}
+
+          {/* Expand indicator */}
+          {canExpand && (
+            <Text style={styles.expandIndicator}>
+              {expanded ? "▼ Show less" : "▶ Show details"}
+            </Text>
+          )}
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
+/**
+ * Format ISO timestamp into relative time or absolute date
+ */
+function formatTimestamp(isoString: string): string {
+  try {
+    const date = new Date(isoString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+    const diffDays = Math.floor(diffMs / 86400000);
+
+    // Less than 1 minute ago
+    if (diffMins < 1) {
+      return "Just now";
+    }
+
+    // Less than 1 hour ago
+    if (diffMins < 60) {
+      return `${diffMins} minute${diffMins !== 1 ? "s" : ""} ago`;
+    }
+
+    // Less than 24 hours ago
+    if (diffHours < 24) {
+      return `${diffHours} hour${diffHours !== 1 ? "s" : ""} ago`;
+    }
+
+    // Less than 7 days ago
+    if (diffDays < 7) {
+      return `${diffDays} day${diffDays !== 1 ? "s" : ""} ago`;
+    }
+
+    // Absolute date for older changes
+    return date.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return isoString;
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: theme.spacing.md,
+  },
+  pressed: {
+    opacity: 0.7,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+  },
+  dot: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    marginTop: 4,
+    marginRight: theme.spacing.md,
+  },
+  content: {
+    flex: 1,
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.borderRadius.md,
+    padding: theme.spacing.md,
+  },
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: theme.spacing.xs,
+  },
+  icon: {
+    fontSize: 20,
+    marginRight: theme.spacing.sm,
+  },
+  title: {
+    flex: 1,
+    fontSize: theme.typography.base,
+    fontWeight: theme.typography.semibold,
+    color: theme.colors.text,
+  },
+  description: {
+    fontSize: theme.typography.sm,
+    color: theme.colors.textSecondary,
+    marginBottom: theme.spacing.xs,
+  },
+  timestamp: {
+    fontSize: theme.typography.xs,
+    color: theme.colors.textMuted,
+    marginTop: theme.spacing.xs,
+  },
+  fieldChanges: {
+    marginTop: theme.spacing.md,
+    paddingTop: theme.spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.border,
+  },
+  fieldChangesTitle: {
+    fontSize: theme.typography.sm,
+    fontWeight: theme.typography.semibold,
+    color: theme.colors.text,
+    marginBottom: theme.spacing.sm,
+  },
+  fieldChange: {
+    marginBottom: theme.spacing.sm,
+  },
+  fieldLabel: {
+    fontSize: theme.typography.sm,
+    fontWeight: theme.typography.medium,
+    color: theme.colors.textSecondary,
+    marginBottom: theme.spacing.xs,
+  },
+  fieldValues: {
+    flexDirection: "row",
+    alignItems: "center",
+    flexWrap: "wrap",
+  },
+  oldValue: {
+    fontSize: theme.typography.sm,
+    color: theme.colors.error,
+    textDecorationLine: "line-through",
+  },
+  arrow: {
+    fontSize: theme.typography.sm,
+    color: theme.colors.textMuted,
+    marginHorizontal: theme.spacing.sm,
+  },
+  newValue: {
+    fontSize: theme.typography.sm,
+    color: theme.colors.success,
+    fontWeight: theme.typography.medium,
+  },
+  expandIndicator: {
+    fontSize: theme.typography.xs,
+    color: theme.colors.primary,
+    marginTop: theme.spacing.sm,
+    fontWeight: theme.typography.medium,
+  },
+});

--- a/src/modules/history/components/HistoryTimeline.tsx
+++ b/src/modules/history/components/HistoryTimeline.tsx
@@ -1,0 +1,87 @@
+/**
+ * UI/UX ENGINEER: HistoryTimeline Component
+ * Chronological list of changes to a trip
+ */
+
+import React from "react";
+import { View, Text, StyleSheet, FlatList } from "react-native";
+import { theme } from "@ui/theme";
+import { ChangeDetailCard } from "./ChangeDetailCard";
+import type { FormattedChange } from "../types";
+
+export interface HistoryTimelineProps {
+  /** Array of formatted changes to display */
+  changes: FormattedChange[];
+  /** Optional empty state message */
+  emptyMessage?: string;
+}
+
+/**
+ * HistoryTimeline - Chronological list of trip changes
+ *
+ * Displays a vertical timeline of all changes made to a trip,
+ * with newest changes at the top. Uses FlatList for performance
+ * with large change histories.
+ *
+ * @example
+ * <HistoryTimeline changes={formattedChanges} />
+ */
+export function HistoryTimeline({
+  changes,
+  emptyMessage = "No history yet",
+}: HistoryTimelineProps) {
+  if (changes.length === 0) {
+    return (
+      <View style={styles.emptyContainer}>
+        <Text style={styles.emptyIcon}>📜</Text>
+        <Text style={styles.emptyMessage}>{emptyMessage}</Text>
+        <Text style={styles.emptyHint}>
+          Changes you make to this trip will appear here
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      data={changes}
+      keyExtractor={(item) => item.id}
+      renderItem={({ item }) => <ChangeDetailCard change={item} />}
+      contentContainerStyle={styles.listContent}
+      showsVerticalScrollIndicator={true}
+      // Performance optimizations
+      removeClippedSubviews={true}
+      maxToRenderPerBatch={10}
+      windowSize={10}
+      initialNumToRender={15}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  listContent: {
+    padding: theme.spacing.lg,
+  },
+  emptyContainer: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: theme.spacing.xl,
+  },
+  emptyIcon: {
+    fontSize: 64,
+    marginBottom: theme.spacing.md,
+  },
+  emptyMessage: {
+    fontSize: theme.typography.lg,
+    fontWeight: theme.typography.semibold,
+    color: theme.colors.text,
+    marginBottom: theme.spacing.sm,
+    textAlign: "center",
+  },
+  emptyHint: {
+    fontSize: theme.typography.base,
+    color: theme.colors.textSecondary,
+    textAlign: "center",
+  },
+});

--- a/src/modules/history/components/index.ts
+++ b/src/modules/history/components/index.ts
@@ -1,0 +1,10 @@
+/**
+ * HISTORY MODULE - Components
+ * UI components for trip history feature
+ */
+
+export { HistoryTimeline } from "./HistoryTimeline";
+export type { HistoryTimelineProps } from "./HistoryTimeline";
+
+export { ChangeDetailCard } from "./ChangeDetailCard";
+export type { ChangeDetailCardProps } from "./ChangeDetailCard";

--- a/src/modules/history/engine/format-changes.ts
+++ b/src/modules/history/engine/format-changes.ts
@@ -1,0 +1,496 @@
+/**
+ * HISTORY MODULE - Format Changes Engine
+ * MODELER: Pure functions for formatting parsed changes into UI-friendly descriptions
+ * PURE FUNCTIONS: No side effects, converts ParsedChange into human-readable strings
+ *
+ * This module takes parsed Automerge changes and formats them into
+ * human-readable descriptions suitable for display in the timeline UI.
+ */
+
+import type {
+  ParsedChange,
+  ChangeType,
+  FieldChange,
+} from "../../automerge/engine/history-parser";
+import type {
+  TripParticipant,
+  TripExpense,
+  TripSettlement,
+} from "../../automerge/types";
+import { formatCurrency } from "@utils/currency";
+
+/**
+ * Formatted change for UI display
+ */
+export interface FormattedChange {
+  /** Unique ID (using timestamp + actor as key) */
+  id: string;
+  /** Type of change */
+  type: ChangeType;
+  /** ISO timestamp */
+  timestamp: string;
+  /** Human-readable title (one-line summary) */
+  title: string;
+  /** Detailed description (optional, for expanded view) */
+  description: string | null;
+  /** Icon/emoji representing the change type */
+  icon: string;
+  /** Color accent for the timeline dot */
+  color: string;
+  /** Field-level changes (for expanded detail view) */
+  fieldChanges?: FormattedFieldChange[];
+}
+
+/**
+ * Formatted field change for detail card
+ */
+export interface FormattedFieldChange {
+  label: string;
+  oldValue: string;
+  newValue: string;
+}
+
+/**
+ * Format parsed changes into UI-friendly display objects
+ *
+ * @param changes - Array of parsed changes from history-parser
+ * @param participants - Map of participant IDs to participant objects (for name lookup)
+ * @returns Array of formatted changes ready for UI display
+ *
+ * @example
+ * const formattedChanges = formatChanges(parsedChanges, participantsMap);
+ * // formattedChanges[0] = {
+ * //   id: '...',
+ * //   title: 'Added Alice to the trip',
+ * //   icon: '👤',
+ * //   color: '#4CAF50',
+ * //   ...
+ * // }
+ */
+export function formatChanges(
+  changes: ParsedChange[],
+  participants: Map<string, TripParticipant>,
+): FormattedChange[] {
+  return changes.map((change) => formatChange(change, participants));
+}
+
+/**
+ * Format a single parsed change
+ *
+ * @param change - Parsed change from Automerge
+ * @param participants - Map of participant IDs to objects
+ * @returns Formatted change for UI
+ */
+function formatChange(
+  change: ParsedChange,
+  participants: Map<string, TripParticipant>,
+): FormattedChange {
+  const id = `${change.timestamp}-${change.actorId}`;
+  const { type, timestamp, details } = change;
+
+  let title = "";
+  let description: string | null = null;
+  let icon = "";
+  let color = "";
+  let fieldChanges: FormattedFieldChange[] | undefined;
+
+  switch (type) {
+    case "trip_created":
+      title = "Trip created";
+      description = "Initial trip setup";
+      icon = "✨";
+      color = "#9C27B0"; // Purple
+      break;
+
+    case "trip_updated":
+      title = "Trip details updated";
+      description = formatTripUpdateDescription(details.fieldChanges || []);
+      icon = "✏️";
+      color = "#2196F3"; // Blue
+      fieldChanges = formatFieldChanges(details.fieldChanges || []);
+      break;
+
+    case "participant_added": {
+      const participant = details.afterSnapshot as TripParticipant | undefined;
+      title = participant ? `Added ${participant.name}` : "Added participant";
+      description = "New participant joined the trip";
+      icon = "👤";
+      color = "#4CAF50"; // Green
+      break;
+    }
+
+    case "participant_updated": {
+      const participant = details.afterSnapshot as TripParticipant | undefined;
+      title = participant
+        ? `Updated ${participant.name}`
+        : "Updated participant";
+      description = formatParticipantUpdateDescription(
+        details.fieldChanges || [],
+      );
+      icon = "✏️";
+      color = "#2196F3"; // Blue
+      fieldChanges = formatFieldChanges(details.fieldChanges || []);
+      break;
+    }
+
+    case "participant_removed": {
+      const participant = details.beforeSnapshot as TripParticipant | undefined;
+      title = participant
+        ? `Removed ${participant.name}`
+        : "Removed participant";
+      description = "Participant left the trip";
+      icon = "👋";
+      color = "#F44336"; // Red
+      break;
+    }
+
+    case "expense_added": {
+      const expense = details.afterSnapshot as TripExpense | undefined;
+      if (expense) {
+        const payer = participants.get(expense.paidById);
+        const payerName = payer ? payer.name : "Unknown";
+        const amount = formatCurrency(
+          expense.convertedAmountMinor,
+          expense.originalCurrency,
+        );
+        title = `${payerName} paid ${amount}`;
+        description = expense.description || "No description";
+      } else {
+        title = "Added expense";
+        description = null;
+      }
+      icon = "💰";
+      color = "#FF9800"; // Orange
+      break;
+    }
+
+    case "expense_updated": {
+      const expense = details.afterSnapshot as TripExpense | undefined;
+      if (expense) {
+        title = `Updated expense: ${expense.description || "Untitled"}`;
+        description = formatExpenseUpdateDescription(
+          details.fieldChanges || [],
+          participants,
+        );
+      } else {
+        title = "Updated expense";
+        description = null;
+      }
+      icon = "✏️";
+      color = "#2196F3"; // Blue
+      fieldChanges = formatFieldChanges(
+        details.fieldChanges || [],
+        participants,
+      );
+      break;
+    }
+
+    case "expense_removed": {
+      const expense = details.beforeSnapshot as TripExpense | undefined;
+      title = expense?.description
+        ? `Removed expense: ${expense.description}`
+        : "Removed expense";
+      description = null;
+      icon = "🗑️";
+      color = "#F44336"; // Red
+      break;
+    }
+
+    case "settlement_added": {
+      const settlement = details.afterSnapshot as TripSettlement | undefined;
+      if (settlement) {
+        const from = participants.get(settlement.fromParticipantId);
+        const to = participants.get(settlement.toParticipantId);
+        const fromName = from ? from.name : "Unknown";
+        const toName = to ? to.name : "Unknown";
+        const amount = formatCurrency(
+          settlement.convertedAmountMinor,
+          settlement.originalCurrency,
+        );
+        title = `${fromName} paid ${toName} ${amount}`;
+        description = settlement.description || "Payment recorded";
+      } else {
+        title = "Recorded payment";
+        description = null;
+      }
+      icon = "💸";
+      color = "#4CAF50"; // Green
+      break;
+    }
+
+    case "settlement_updated": {
+      const settlement = details.afterSnapshot as TripSettlement | undefined;
+      title = settlement?.description
+        ? `Updated payment: ${settlement.description}`
+        : "Updated payment";
+      description = formatSettlementUpdateDescription(
+        details.fieldChanges || [],
+        participants,
+      );
+      icon = "✏️";
+      color = "#2196F3"; // Blue
+      fieldChanges = formatFieldChanges(
+        details.fieldChanges || [],
+        participants,
+      );
+      break;
+    }
+
+    case "settlement_removed": {
+      const settlement = details.beforeSnapshot as TripSettlement | undefined;
+      title = settlement?.description
+        ? `Removed payment: ${settlement.description}`
+        : "Removed payment";
+      description = null;
+      icon = "🗑️";
+      color = "#F44336"; // Red
+      break;
+    }
+
+    default:
+      title = change.message || "Unknown change";
+      description = null;
+      icon = "❓";
+      color = "#9E9E9E"; // Gray
+      break;
+  }
+
+  return {
+    id,
+    type,
+    timestamp,
+    title,
+    description,
+    icon,
+    color,
+    fieldChanges,
+  };
+}
+
+/**
+ * Format trip update description
+ */
+function formatTripUpdateDescription(fieldChanges: FieldChange[]): string {
+  const descriptions = fieldChanges.map((change) => {
+    switch (change.fieldPath) {
+      case "name":
+        return `Renamed to "${change.newValue}"`;
+      case "emoji":
+        return `Changed emoji to ${change.newValue}`;
+      case "currency":
+        return `Changed currency to ${change.newValue}`;
+      case "startDate":
+        return `Changed start date to ${formatDate(change.newValue as string)}`;
+      case "endDate":
+        return change.newValue
+          ? `Changed end date to ${formatDate(change.newValue as string)}`
+          : "Removed end date";
+      default:
+        return `Updated ${change.fieldPath}`;
+    }
+  });
+
+  return descriptions.join(", ");
+}
+
+/**
+ * Format participant update description
+ */
+function formatParticipantUpdateDescription(
+  fieldChanges: FieldChange[],
+): string {
+  const descriptions = fieldChanges.map((change) => {
+    switch (change.fieldPath) {
+      case "name":
+        return `Renamed to "${change.newValue}"`;
+      case "color":
+        return `Changed color`;
+      default:
+        return `Updated ${change.fieldPath}`;
+    }
+  });
+
+  return descriptions.join(", ");
+}
+
+/**
+ * Format expense update description
+ */
+function formatExpenseUpdateDescription(
+  fieldChanges: FieldChange[],
+  participants: Map<string, TripParticipant>,
+): string {
+  const descriptions = fieldChanges.map((change) => {
+    switch (change.fieldPath) {
+      case "description":
+        return `Renamed to "${change.newValue}"`;
+      case "convertedAmountMinor":
+      case "originalAmountMinor": {
+        const oldAmount = formatCurrency(change.oldValue as number, "USD");
+        const newAmount = formatCurrency(change.newValue as number, "USD");
+        return `Amount changed from ${oldAmount} to ${newAmount}`;
+      }
+      case "paidById": {
+        const oldPayer = participants.get(change.oldValue as string);
+        const newPayer = participants.get(change.newValue as string);
+        const oldName = oldPayer ? oldPayer.name : "Unknown";
+        const newName = newPayer ? newPayer.name : "Unknown";
+        return `Payer changed from ${oldName} to ${newName}`;
+      }
+      case "date":
+        return `Date changed to ${formatDate(change.newValue as string)}`;
+      default:
+        return `Updated ${change.fieldPath}`;
+    }
+  });
+
+  return descriptions.join(", ");
+}
+
+/**
+ * Format settlement update description
+ */
+function formatSettlementUpdateDescription(
+  fieldChanges: FieldChange[],
+  participants: Map<string, TripParticipant>,
+): string {
+  const descriptions = fieldChanges.map((change) => {
+    switch (change.fieldPath) {
+      case "convertedAmountMinor":
+      case "originalAmountMinor": {
+        const oldAmount = formatCurrency(change.oldValue as number, "USD");
+        const newAmount = formatCurrency(change.newValue as number, "USD");
+        return `Amount changed from ${oldAmount} to ${newAmount}`;
+      }
+      case "fromParticipantId": {
+        const oldPayer = participants.get(change.oldValue as string);
+        const newPayer = participants.get(change.newValue as string);
+        const oldName = oldPayer ? oldPayer.name : "Unknown";
+        const newName = newPayer ? newPayer.name : "Unknown";
+        return `Payer changed from ${oldName} to ${newName}`;
+      }
+      case "toParticipantId": {
+        const oldPayee = participants.get(change.oldValue as string);
+        const newPayee = participants.get(change.newValue as string);
+        const oldName = oldPayee ? oldPayee.name : "Unknown";
+        const newName = newPayee ? newPayee.name : "Unknown";
+        return `Recipient changed from ${oldName} to ${newName}`;
+      }
+      case "description":
+        return `Description changed to "${change.newValue}"`;
+      case "date":
+        return `Date changed to ${formatDate(change.newValue as string)}`;
+      default:
+        return `Updated ${change.fieldPath}`;
+    }
+  });
+
+  return descriptions.join(", ");
+}
+
+/**
+ * Format field changes for detail card
+ */
+function formatFieldChanges(
+  fieldChanges: FieldChange[],
+  participants?: Map<string, TripParticipant>,
+): FormattedFieldChange[] {
+  return fieldChanges.map((change) => {
+    const label = formatFieldLabel(change.fieldPath);
+    const oldValue = formatFieldValue(
+      change.fieldPath,
+      change.oldValue,
+      participants,
+    );
+    const newValue = formatFieldValue(
+      change.fieldPath,
+      change.newValue,
+      participants,
+    );
+
+    return { label, oldValue, newValue };
+  });
+}
+
+/**
+ * Format field label for display
+ */
+function formatFieldLabel(fieldPath: string): string {
+  switch (fieldPath) {
+    case "name":
+      return "Name";
+    case "emoji":
+      return "Emoji";
+    case "currency":
+      return "Currency";
+    case "startDate":
+      return "Start Date";
+    case "endDate":
+      return "End Date";
+    case "description":
+      return "Description";
+    case "originalAmountMinor":
+    case "convertedAmountMinor":
+      return "Amount";
+    case "paidById":
+      return "Paid By";
+    case "fromParticipantId":
+      return "From";
+    case "toParticipantId":
+      return "To";
+    case "date":
+      return "Date";
+    case "color":
+      return "Color";
+    default:
+      return fieldPath;
+  }
+}
+
+/**
+ * Format field value for display
+ */
+function formatFieldValue(
+  fieldPath: string,
+  value: unknown,
+  participants?: Map<string, TripParticipant>,
+): string {
+  if (value === null || value === undefined) {
+    return "(none)";
+  }
+
+  switch (fieldPath) {
+    case "originalAmountMinor":
+    case "convertedAmountMinor":
+      return formatCurrency(value as number, "USD");
+    case "paidById":
+    case "fromParticipantId":
+    case "toParticipantId": {
+      if (!participants) return String(value);
+      const participant = participants.get(value as string);
+      return participant ? participant.name : String(value);
+    }
+    case "startDate":
+    case "endDate":
+    case "date":
+      return formatDate(value as string);
+    default:
+      return String(value);
+  }
+}
+
+/**
+ * Format ISO date string for display
+ */
+function formatDate(isoString: string): string {
+  try {
+    const date = new Date(isoString);
+    return date.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return String(isoString);
+  }
+}

--- a/src/modules/history/hooks/index.ts
+++ b/src/modules/history/hooks/index.ts
@@ -1,0 +1,7 @@
+/**
+ * HISTORY MODULE - Hooks
+ * React hooks for trip history feature
+ */
+
+export { useFormattedHistory } from "./use-formatted-history";
+export type { UseFormattedHistoryResult } from "./use-formatted-history";

--- a/src/modules/history/hooks/use-formatted-history.ts
+++ b/src/modules/history/hooks/use-formatted-history.ts
@@ -1,0 +1,98 @@
+/**
+ * HISTORY MODULE - useFormattedHistory Hook
+ * UI INTEGRATION: Transforms Automerge operations into UI-friendly format
+ *
+ * This hook combines useTripHistory with formatChanges to provide
+ * fully formatted change events ready for display in the UI.
+ */
+
+import { useMemo } from "react";
+import { useTripHistory } from "../../automerge/hooks/use-trip-history";
+import { useParticipants } from "../../participants/hooks/use-participants";
+import { formatChanges } from "../engine/format-changes";
+import type { FormattedChange } from "../types";
+
+/**
+ * Hook result
+ */
+export interface UseFormattedHistoryResult {
+  /** Formatted changes ready for UI display */
+  changes: FormattedChange[];
+  /** Loading state (combines history + participants loading) */
+  loading: boolean;
+  /** Error state */
+  error: Error | null;
+  /** Refetch function */
+  refetch: () => Promise<void>;
+}
+
+/**
+ * Hook to get formatted history changes for a trip
+ *
+ * This hook:
+ * 1. Loads trip history from Automerge (useTripHistory)
+ * 2. Loads participants for name lookup (useParticipants)
+ * 3. Formats changes into human-readable events (formatChanges)
+ * 4. Returns formatted changes ready for timeline display
+ *
+ * @param tripId - Trip UUID
+ * @returns Formatted changes with loading/error state
+ *
+ * @example
+ * function TripHistoryScreen({ tripId }) {
+ *   const { changes, loading, error } = useFormattedHistory(tripId);
+ *
+ *   if (loading) return <LoadingSpinner />;
+ *   if (error) return <ErrorView error={error} />;
+ *
+ *   return (
+ *     <HistoryTimeline changes={changes} />
+ *   );
+ * }
+ */
+export function useFormattedHistory(tripId: string): UseFormattedHistoryResult {
+  // Load raw history from Automerge
+  const {
+    changes: rawChanges,
+    loading: historyLoading,
+    error: historyError,
+    refetch: refetchHistory,
+  } = useTripHistory(tripId);
+
+  // Load participants for name lookup
+  const {
+    participants,
+    loading: participantsLoading,
+    refetch: refetchParticipants,
+  } = useParticipants(tripId);
+
+  // Create participant map for efficient lookup
+  const participantMap = useMemo(() => {
+    const map = new Map();
+    participants.forEach((p) => {
+      map.set(p.id, p);
+    });
+    return map;
+  }, [participants]);
+
+  // Format changes for UI display
+  const formattedChanges = useMemo(() => {
+    if (historyLoading || participantsLoading) {
+      return [];
+    }
+
+    return formatChanges(rawChanges, participantMap);
+  }, [rawChanges, participantMap, historyLoading, participantsLoading]);
+
+  // Combined refetch
+  const refetch = async () => {
+    await Promise.all([refetchHistory(), refetchParticipants()]);
+  };
+
+  return {
+    changes: formattedChanges,
+    loading: historyLoading || participantsLoading,
+    error: historyError,
+    refetch,
+  };
+}

--- a/src/modules/history/index.ts
+++ b/src/modules/history/index.ts
@@ -1,0 +1,22 @@
+/**
+ * HISTORY MODULE - Public API
+ * Trip history feature for viewing all changes
+ */
+
+// Types
+export type {
+  FormattedChange,
+  FormattedFieldChange,
+  ParsedChange,
+  ChangeType,
+  ChangeDetails,
+  FieldChange,
+} from "./types";
+
+// Hooks
+export { useFormattedHistory } from "./hooks";
+export type { UseFormattedHistoryResult } from "./hooks";
+
+// Components
+export { HistoryTimeline, ChangeDetailCard } from "./components";
+export type { HistoryTimelineProps, ChangeDetailCardProps } from "./components";

--- a/src/modules/history/screens/TripHistoryScreen.tsx
+++ b/src/modules/history/screens/TripHistoryScreen.tsx
@@ -1,0 +1,107 @@
+/**
+ * UI/UX ENGINEER: Trip History Screen
+ * Displays chronological timeline of all changes to a trip
+ */
+
+import React, { useEffect } from "react";
+import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
+import { useLocalSearchParams, useNavigation } from "expo-router";
+import { theme } from "@ui/theme";
+import { Card } from "@ui/components";
+import { useFormattedHistory } from "../hooks/use-formatted-history";
+import { HistoryTimeline } from "../components";
+
+export default function TripHistoryScreen() {
+  const { id } = useLocalSearchParams<{ id?: string }>();
+  const tripId = id?.trim() || null;
+
+  if (!tripId) {
+    return (
+      <View style={theme.commonStyles.container}>
+        <View style={theme.commonStyles.centerContent}>
+          <Text style={styles.errorText}>
+            Invalid trip. Please select a trip again.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  return <TripHistoryScreenContent tripId={tripId} />;
+}
+
+function TripHistoryScreenContent({ tripId }: { tripId: string }) {
+  const navigation = useNavigation();
+  const { changes, loading, error } = useFormattedHistory(tripId);
+
+  // Update native header title
+  useEffect(() => {
+    navigation.setOptions({
+      title: "History",
+    });
+  }, [navigation]);
+
+  if (error) {
+    return (
+      <View style={theme.commonStyles.container}>
+        <View style={styles.errorContainer}>
+          <Card style={styles.errorCard}>
+            <Text style={styles.errorTitle}>Failed to load history</Text>
+            <Text style={styles.errorMessage}>{error.message}</Text>
+            <Text style={styles.errorHint}>
+              This trip may not have an Automerge document yet. History is only
+              available for trips created or migrated after the Automerge
+              integration.
+            </Text>
+          </Card>
+        </View>
+      </View>
+    );
+  }
+
+  if (loading) {
+    return (
+      <View style={theme.commonStyles.container}>
+        <View style={theme.commonStyles.centerContent}>
+          <ActivityIndicator size="large" color={theme.colors.primary} />
+          <Text style={theme.commonStyles.loadingText}>Loading history...</Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={theme.commonStyles.container}>
+      <HistoryTimeline changes={changes} emptyMessage="No changes yet" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  errorContainer: {
+    padding: theme.spacing.lg,
+  },
+  errorCard: {
+    backgroundColor: theme.colors.surface,
+  },
+  errorTitle: {
+    fontSize: theme.typography.lg,
+    fontWeight: theme.typography.bold,
+    color: theme.colors.error,
+    marginBottom: theme.spacing.sm,
+  },
+  errorMessage: {
+    fontSize: theme.typography.base,
+    color: theme.colors.text,
+    marginBottom: theme.spacing.md,
+  },
+  errorHint: {
+    fontSize: theme.typography.sm,
+    color: theme.colors.textSecondary,
+    fontStyle: "italic",
+  },
+  errorText: {
+    fontSize: theme.typography.base,
+    color: theme.colors.text,
+  },
+});

--- a/src/modules/history/types.ts
+++ b/src/modules/history/types.ts
@@ -1,0 +1,17 @@
+/**
+ * HISTORY MODULE - Type Definitions
+ * Domain types for trip history feature
+ */
+
+// Re-export engine types
+export type {
+  FormattedChange,
+  FormattedFieldChange,
+} from "./engine/format-changes";
+
+export type {
+  ParsedChange,
+  ChangeType,
+  ChangeDetails,
+  FieldChange,
+} from "../automerge/engine/history-parser";

--- a/src/modules/trips/screens/components/TripActionCards.tsx
+++ b/src/modules/trips/screens/components/TripActionCards.tsx
@@ -91,6 +91,21 @@ export function TripActionCards({
             : "View trip insights and breakdowns"}
         </Text>
       </Card>
+
+      <Card
+        style={styles.actionCard}
+        onPress={() =>
+          onNavigate({
+            pathname: "/trips/[id]/history" as any,
+            params: { id: tripId },
+          })
+        }
+      >
+        <Text style={styles.actionTitle}>History</Text>
+        <Text style={styles.actionBody}>
+          View all changes made to this trip
+        </Text>
+      </Card>
     </View>
   );
 }


### PR DESCRIPTION
Add comprehensive history timeline UI for viewing all changes to a trip. Follows three-layer architecture (engine → hooks → UI) as specified in AUTOMERGE_IMPLEMENTATION_PLAN.md.

**Engine Layer (Pure Functions):**
- history-parser.ts: Parse Automerge.getHistory() into structured changes
- format-changes.ts: Transform parsed changes into human-readable UI text

**Hooks Layer (React Integration):**
- use-trip-history.ts: Load Automerge doc and parse operation log
- use-formatted-history.ts: Combine history + participants for formatted output

**UI Layer (Components):**
- HistoryTimeline.tsx: FlatList timeline of all changes (newest-first)
- ChangeDetailCard.tsx: Expandable card with field-level change details
- TripHistoryScreen.tsx: Full screen history view with loading/error states

**Integration:**
- Added History card to Trip Dashboard (TripActionCards)
- Created route: /trips/[id]/history
- Supports all change types: trip metadata, participants, expenses, settlements
- Human-readable descriptions (e.g., "Alice paid $50.00", "Updated trip name")
- Relative timestamps (e.g., "2 hours ago", "3 days ago")
- Field-by-field diffs in expandable cards
- Empty state handling for trips without Automerge docs

**Testing:**
- All files pass TypeScript type-check
- All files pass ESLint validation
- Uses deterministic error handling (createAppError)
- Follows accessibility guidelines (screen reader labels, touch targets)

Implements Phase 3 tasks from AUTOMERGE_IMPLEMENTATION_PLAN.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)